### PR TITLE
Allow error callback handle login failure case.

### DIFF
--- a/jqzabbix/jqzabbix.js
+++ b/jqzabbix/jqzabbix.js
@@ -88,9 +88,15 @@ function createAjaxOption(method, params, success, error, complete) {
                 errormsg = {
                     data: 'Network error'
                 };
+                if (typeof error === 'function') {
+                    error();
+                }
             }
             else if ('error' in response) {
                 errormsg = response.error;
+                if (typeof error === 'function') {
+                    error();
+                }
             }
             
             // resuest success


### PR DESCRIPTION
If userLogin() contains a wrong password,
jquery itself will call its success callback
containing "error" in response (jqzabbix.js L95).

In that case neither jqzabbix's success callback or
its error callback will be called.

To avoid this problem, current the jqzabbix user
needs to rely on its complete callback, checking
jqzabbix's errormsg variable everytime,
which seems nasty.

Allow me to just rely on error callback,
because it is actually an error from Zabbix API
perspective.
